### PR TITLE
Fix: Paymenter Error

### DIFF
--- a/Midtrans.php
+++ b/Midtrans.php
@@ -76,14 +76,18 @@ class Midtrans extends Gateway
                 'id'       => $item->id ?? uniqid(),
                 'price'    => round($item->price, 2),
                 'quantity' => $item->quantity ?? 1,
-                'name'     => $item->description ?? 'Item',
+                'name'     => substr($item->description ?? 'Item', 0, 50),
             ];
         })->toArray();
+        
+        $grossAmount = collect($itemDetails)->sum(function ($item) {
+            return $item['price'] * $item['quantity'];
+        });
 
         $payload = [
             'transaction_details' => [
                 'order_id'     => $orderId,
-                'gross_amount' => round($total, 2),
+                'gross_amount' => $grossAmount,
             ],
             'item_details' => $itemDetails,
         ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
 use Paymenter\Extensions\Gateways\Midtrans\Midtrans;
 
-Route::post('/extensions/midtrans/webhook', [Midtrans::class, 'webhook'])->name('extensions.gateways.midtrans.webhook');
+Route::post('/extensions/midtrans/webhook', [Midtrans::class, 'webhook'])->withoutMiddleware([VerifyCsrfToken::class])->name('extensions.gateways.midtrans.webhook');


### PR DESCRIPTION
1. Invoice stuck at "Pending Processing"
This happens after a successful transaction, but the invoice status in Paymenter is still "Pending Processing".  
Cause: Midtrans failed to send a notification to the webhook.
POST https://my.domain.id/extensions/midtrans/webhook  
Response: URL not found


2. Product name too long
This error occurs when the product name is too long, causing incorrect gross amount calculation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected transaction amount calculation for Midtrans payments to ensure accuracy based on individual item quantities and prices.
  * Enhanced item name formatting in Midtrans transaction details for improved system compatibility.

* **Chores**
  * Updated webhook security configuration for Midtrans payment notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->